### PR TITLE
Use root path for --applications settings

### DIFF
--- a/src/Mono.WebServer/ApplicationServer.cs
+++ b/src/Mono.WebServer/ApplicationServer.cs
@@ -258,7 +258,7 @@ namespace Mono.WebServer
 				}
 
 				string vpath = app [pos++];
-				string realpath = app[pos++];
+				string realpath = Path.Combine(PhysicalRoot, app[pos++]);
 
 				if (!vpath.EndsWith ("/"))
 					vpath += "/";


### PR DESCRIPTION
Path.GetFullPath return path for start catalog, no root settings path.

Test file /var/www/well/index.html

Without my fix:
lad@mblkolo:/var/www/well$ xsp4 --port 8080 ->  http://localhost:8080/index.html
lad@mblkolo:/var/www/well$ xsp4 --port 8080 --root /var/www/well ->  http://localhost:8080/index.html
lad@mblkolo:/var/www$ xsp4 --port 8080 ->  http://localhost:8080/well/index.html
lad@mblkolo:/var/www$ xsp4 --port 8080 --root /var/www/well -> http://localhost:8080/well/index.html (what?)
lad@mblkolo:/var/www$ xsp4 --port 8080 --root /var/www/well --applications /:/var/www/well/ -> http://localhost:8080/index.html (now I use this)

With my fix
lad@mblkolo:/var/www/well$ xsp4 --port 8080 ->  http://localhost:8080/index.html
lad@mblkolo:/var/www/well$ xsp4 --port 8080 --root /var/www/well ->  http://localhost:8080/index.html
lad@mblkolo:/var/www$ xsp4 --port 8080 ->  http://localhost:8080/well/index.html
lad@mblkolo:/var/www$ xsp4 --port 8080 --root /var/www/well -> http://localhost:8080/index.html (it's ok)